### PR TITLE
Replace minimist with Node's built-in `util.parseArgs`

### DIFF
--- a/cmd.cjs
+++ b/cmd.cjs
@@ -17,31 +17,37 @@ const { Logger, Cli } = require("./cli.js");
 
 try {
   const defaults = Cli.getDefaultOptions();
-  for(let key in defaults) {
-    if(key.toLowerCase() !== key) {
-      defaults[key.toLowerCase()] = defaults[key];
-      delete defaults[key];
-    }
-  }
 
-  const argv = require("minimist")(process.argv.slice(2), {
-    string: [
-      "dir",
-      "input", // alias for dir
-      "port",
-    ],
-    boolean: [
-      "version",
-      "help",
-      "domdiff",
-    ],
-    default: defaults,
-    unknown: function (unknownArgument) {
-      throw new Error(
-        `We don’t know what '${unknownArgument}' is. Use --help to see the list of supported commands.`
-      );
+  const { parseArgs } = require("node:util");
+
+  const args = process.argv.slice(2);
+  const options = {
+    dir: {
+      type: "string",
     },
-  });
+    input: {
+      type: "string",
+      default: defaults.input,
+    },
+    port: {
+      type: "string",
+      default: defaults.port,
+    },
+    domdiff: {
+      type: "boolean",
+      default: defaults.domDiff,
+    },
+    help: {
+      type: "boolean",
+      default: false,
+    },
+    version: {
+      type: "boolean",
+      default: false,
+    },
+  };
+
+  const { values: argv } = parseArgs({ args, options });
 
   // Older Node friendly import workaround (this is a CommonJS file)
   import("obug").then(({ createDebug }) => {
@@ -75,5 +81,13 @@ try {
     });
   }
 } catch (e) {
+  if (e instanceof TypeError) {
+    const unknownArgument = e.message.split(" ").pop();
+
+    e = new Error(
+      `We don’t know what ${unknownArgument} is. Use --help to see the list of supported commands.`
+    );
+  }
+
   Logger.fatal("Fatal Error:", e)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "chokidar": "^5.0.0",
         "finalhandler": "^2.1.1",
         "mime": "^4.1.0",
-        "minimist": "^1.2.8",
         "morphdom": "^2.7.8",
         "obug": "^2.1.4",
         "range-parser": "^1.3.0",
@@ -1333,15 +1332,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "chokidar": "^5.0.0",
     "finalhandler": "^2.1.1",
     "mime": "^4.1.0",
-    "minimist": "^1.2.8",
     "morphdom": "^2.7.8",
     "obug": "^2.1.4",
     "range-parser": "^1.3.0",


### PR DESCRIPTION
In the spirit of v3.0.0-alpha.11 dropping nine dependencies, this _completely unsolicited_ Pull Request replaces minimist with Node's built-in `util.parseArgs` capability.

`util.parseArgs` has been available since Node v16.17.0 and is a suitable replacement for minimist in some cases. This package now requires Node >= v22.15, so it seemed reasonable to give this a shot.

Thanks for considering this change!

## Related Links

- https://npmx.dev/package/minimist
- https://e18e.dev/docs/replacements/parseargs
- https://nodejs.org/api/util.html#utilparseargsconfig