### PR TITLE
Fix unhandled exception in request handling crashes the process

### DIFF
--- a/server.js
+++ b/server.js
@@ -851,7 +851,14 @@ export default class EleventyDevServer {
     bound.reverse();
 
     let [first] = bound;
-    await first();
+    try {
+      await first();
+    } catch(e) {
+      if(!res.headersSent) {
+        res.statusCode = 400;
+        res.end("Bad Request");
+      }
+    }
   }
 
   getHosts() {


### PR DESCRIPTION
Fixes #150.

## Summary

`getOutputDirFilePath()` throws `Error("Invalid path")` as its normal rejection path for an out-of-bounds request, but nothing in the call chain up to the raw `http.Server` request handler caught it. Since `onRequestHandler` is `async`, the thrown error becomes a rejected promise with no `.catch()` attached by the caller — an unhandled rejection that terminates the entire Node.js process on a single crafted GET request.

## Fix

Wrap the middleware-chain invocation in `onRequestHandler` in a try/catch and respond with a normal 400 instead of letting the exception escape:

```js
let [first] = bound;
try {
  await first();
} catch(e) {
  if(!res.headersSent) {
    res.statusCode = 400;
    res.end("Bad Request");
  }
}
```

## Verification

- Full existing test suite: 32/32 passing, no regressions.
- PoC that previously crashed the server with a single request now returns 400, and the server stays alive for subsequent requests:
  ```
  $ curl http://localhost:PORT/%2e%2e%2fsecret.txt
  # before: process crashes, subsequent requests get connection refused
  # after:  HTTP 400, server stays up
  ```

See #150 for the full report and original reproduction.